### PR TITLE
Upgrade unikernel for MirageOS 4

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -8,7 +8,7 @@ freebsd_task:
       - OCAML_VERSION: 4.10.0
   pkg_install_script: pkg install -y ocaml-opam gmp gmake pkgconf bash
   ocaml_script: opam init -a --comp=$OCAML_VERSION
-  mirage_script: eval `opam env` && opam install -y mirage lwt
+  mirage_script: eval `opam env` && opam install -y mirage>=4.0 lwt
   configure_script: eval `opam env` && mirage configure -t hvt --no-depext
   depend_script: eval `opam env` && make depend
   build_script: eval `opam env` && mirage build

--- a/config.ml
+++ b/config.ml
@@ -35,10 +35,10 @@ let email =
   Key.(create "email" Arg.(opt (some string) None doc))
 
 let keys = Key.[
-    abstract dns_key ; abstract dns_server ; abstract port ;
-    abstract production ;
-    abstract account_key_seed ; abstract account_key_type ;
-    abstract account_bits ; abstract email
+    v dns_key ; v dns_server ; v port ;
+    v production ;
+    v account_key_seed ; v account_key_type ;
+    v account_bits ; v email
   ]
 
 let packages =

--- a/config.ml
+++ b/config.ml
@@ -55,7 +55,7 @@ let packages =
     package ~min:"5.0.0" ~sublibs:[ "mirage" ] "dns-server";
     package "randomconv";
     package ~min:"0.3.0" "domain-name";
-    package ~min:"3.10.4" "mirage-runtime";
+    package ~min:"4.0.0" "mirage-runtime";
 ]
 
 let client =


### PR DESCRIPTION
Hello,
I have created this pull request in the context of this https://github.com/mirage/mirage/issues/1281.
However, this unikernel did not need many changes at all, so I simply changed the calls to `Key.abstract` to `Key.v` because it was [deprecated](https://github.com/mirage/mirage/blob/8b16bcfb7a190ac2e01bd23fa9bd9357a0d03726/lib/mirage/mirage_key.mli#L35) in `MirageOS 4`